### PR TITLE
Fix links in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -161,12 +161,12 @@ bpt_plot_predictions(analysis, prediction = "ratios")
 Additional information is available from the [`bisonpicsuite`](https://poissonconsulting.github.io/bisonpicsuite/) and [`bisonpictools`](https://poissonconsulting.github.io/bisonpictools/) websites, which contain the following articles:
 
 - `bisonpicsuite`
-  - [Getting Started with bisonpicsuite](https://poissonconsulting.github.io/bisonpicsuite/bisonpicsuite-getting-started.html)
-  - [Bisonpic User Guide](https://poissonconsulting.github.io/bisonpicsuite/bisonpic-user-guide.html)
+  - [Getting Started with bisonpicsuite](https://poissonconsulting.github.io/bisonpicsuite/articles/bisonpicsuite-getting-started.html)
+  - [Bisonpic User Guide](https://poissonconsulting.github.io/bisonpicsuite/articles/bisonpic-user-guide.html)
 
 - `bisonpictools`
-  - [Getting Started with bisonpictools](https://poissonconsulting.github.io/bisonpictools/bisonpictools-getting-started.html)
-  - [Analytical Methods](https://poissonconsulting.github.io/bisonpictools/bisonpic-methods.html)
+  - [Getting Started with bisonpictools](https://poissonconsulting.github.io/bisonpictools/articles/bisonpictools-getting-started.html)
+  - [Analytical Methods](https://poissonconsulting.github.io/bisonpictools/articles/bisonpic-methods.html)
   
 ## Contribution
 


### PR DESCRIPTION
Added the /articles/ section to the vignette URLs.