### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-7388-1222")),
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0002-7683-4592")),
-    person("Troy", "Hegel", , "Troy.Hegel@gov.ab.ca", role = "ctb"),
+    person("Troy", "Hegel", , "Troy.Hegel@gov.ab.ca", role = "ctb",
+           comment = c(ORCID = "0000-0001-5363-7716")),
     person("Province of Alberta", role = "cph")
   )
 Description: Facilitates the manipulation, exploration, and analysis of wood bison camera trap data.


### PR DESCRIPTION
Add Troy Hegel's ORCID (0000-0001-5363-7716).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)