### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,4 +14,5 @@
 ^_pkgdown\.yml$
 ^README\.Rmd$
 ^README_files$
-^CODE_OF_CONDUCT\.md$
+^CODE_OF_CONDUCT\.md$^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/bpt-analyse.R
+++ b/R/bpt-analyse.R
@@ -35,12 +35,13 @@
 #' )
 #' }
 bpt_analyse <- function(
-    event_data,
-    location_data,
-    census_data,
-    proportion_calf_data,
-    nthin = 10L,
-    analysis_mode = "report") {
+  event_data,
+  location_data,
+  census_data,
+  proportion_calf_data,
+  nthin = 10L,
+  analysis_mode = "report"
+) {
   chk::chk_integer(nthin)
   chk::chk_gte(nthin, 1L)
   chk::chk_subset(analysis_mode, c("report", "quick", "debug"))

--- a/R/bpt-check-data.R
+++ b/R/bpt-check-data.R
@@ -54,13 +54,14 @@
 #' try(event <- bpt_check_data(event = event_data, complete = TRUE))
 #' }
 bpt_check_data <- function(
-    event = NULL,
-    location = NULL,
-    census = NULL,
-    proportion_calf = NULL,
-    complete = FALSE,
-    join = FALSE,
-    check_study_years = FALSE) {
+  event = NULL,
+  location = NULL,
+  census = NULL,
+  proportion_calf = NULL,
+  complete = FALSE,
+  join = FALSE,
+  check_study_years = FALSE
+) {
   data <- chktemplate::check_data_format(
     event = event,
     location = location,

--- a/R/bpt-manipulate-data-analysis.R
+++ b/R/bpt-manipulate-data-analysis.R
@@ -29,10 +29,11 @@
 #'   proportion_calf_data = proportion_calf_data
 #' )
 bpt_manipulate_data_analysis <- function(
-    event_data,
-    location_data,
-    census_data,
-    proportion_calf_data) {
+  event_data,
+  location_data,
+  census_data,
+  proportion_calf_data
+) {
   data <- bpt_check_data(
     event = event_data,
     location = location_data,
@@ -55,18 +56,25 @@ bpt_manipulate_data_analysis <- function(
         dttr2::dtt_doy(dttr2::dtt_date_from_ints(.data$census_year, 4L, 1L)),
       leap_year = as.integer(
         dttr2::dtt_leap_year(.data$date) &
-          (.data$date >= dttr2::dtt_date_from_ints(
-            year = .data$census_year,
-            month = 3L,
-            day = 1L
-          )
-          )
+          (.data$date >=
+            dttr2::dtt_date_from_ints(
+              year = .data$census_year,
+              month = 3L,
+              day = 1L
+            ))
       ),
-      doy = dplyr::if_else(.data$doy < 0, .data$doy + 366 + .data$leap_year, .data$doy),
+      doy = dplyr::if_else(
+        .data$doy < 0,
+        .data$doy + 366 + .data$leap_year,
+        .data$doy
+      ),
       census_doy = base::as.integer(.data$doy),
     ) |>
     dplyr::select(
-      "census", "census_cv", "census_study_year", "census_doy"
+      "census",
+      "census_cv",
+      "census_study_year",
+      "census_doy"
     )
 
   prop_calf_data <- data$proportion_calf |>
@@ -82,21 +90,32 @@ bpt_manipulate_data_analysis <- function(
       ),
       prop_calf_study_year = dttr2::dtt_study_year(date, start = 4L),
       doy = dttr2::dtt_doy(.data$date) -
-        dttr2::dtt_doy(dttr2::dtt_date_from_ints(.data$proportion_calf_year, 4L, 1L)),
+        dttr2::dtt_doy(dttr2::dtt_date_from_ints(
+          .data$proportion_calf_year,
+          4L,
+          1L
+        )),
       leap_year = as.integer(
         dttr2::dtt_leap_year(.data$date) &
-          (.data$date >= dttr2::dtt_date_from_ints(
-            year = .data$proportion_calf_year,
-            month = 3L,
-            day = 1L
-          )
-          )
+          (.data$date >=
+            dttr2::dtt_date_from_ints(
+              year = .data$proportion_calf_year,
+              month = 3L,
+              day = 1L
+            ))
       ),
-      doy = dplyr::if_else(.data$doy < 0, .data$doy + 366 + .data$leap_year, .data$doy),
+      doy = dplyr::if_else(
+        .data$doy < 0,
+        .data$doy + 366 + .data$leap_year,
+        .data$doy
+      ),
       prop_calf_doy = base::as.integer(.data$doy),
     ) |>
     dplyr::select(
-      "prop_calf", "prop_calf_cv", "prop_calf_study_year", "prop_calf_doy"
+      "prop_calf",
+      "prop_calf_cv",
+      "prop_calf_study_year",
+      "prop_calf_doy"
     )
 
   seasons_long <-
@@ -111,9 +130,20 @@ bpt_manipulate_data_analysis <- function(
   data <-
     data$event |>
     dplyr::mutate(
-      groupsize_total = .data$fa + .data$f1 + .data$f0 + .data$fu + .data$ma +
-        .data$m3 + .data$m2 + .data$m1 + .data$m0 + .data$mu + .data$ua +
-        .data$u1 + .data$u0 + .data$uu,
+      groupsize_total = .data$fa +
+        .data$f1 +
+        .data$f0 +
+        .data$fu +
+        .data$ma +
+        .data$m3 +
+        .data$m2 +
+        .data$m1 +
+        .data$m0 +
+        .data$mu +
+        .data$ua +
+        .data$u1 +
+        .data$u0 +
+        .data$uu,
       calf = .data$f0 + .data$m0 + .data$u0,
       yearling = .data$f1 + .data$m1 + .data$u1,
       adult = .data$fa + .data$m2 + .data$m3 + .data$ma + .data$ua,
@@ -176,10 +206,31 @@ bpt_manipulate_data_analysis <- function(
       id = base::factor(seq_len(dplyr::n()))
     ) |>
     dplyr::select(
-      "f0", "f1", "m2", "m3", "ma", "fa", "m0", "m1", "u0", "u1", "ua",
-      "calf", "yearling", "adult", "groupsize_total",
-      "annual", "week", "weekfac", "season", "doy", "doy_fac",
-      "location", "location_weekfac", "season_annual", "id"
+      "f0",
+      "f1",
+      "m2",
+      "m3",
+      "ma",
+      "fa",
+      "m0",
+      "m1",
+      "u0",
+      "u1",
+      "ua",
+      "calf",
+      "yearling",
+      "adult",
+      "groupsize_total",
+      "annual",
+      "week",
+      "weekfac",
+      "season",
+      "doy",
+      "doy_fac",
+      "location",
+      "location_weekfac",
+      "season_annual",
+      "id"
     )
 
   chk::chk_not_any_na(data)

--- a/R/bpt-manipulate-data-plot.R
+++ b/R/bpt-manipulate-data-plot.R
@@ -27,8 +27,9 @@
 #'   location_data
 #' )
 bpt_manipulate_data_plot <- function(
-    event_data,
-    location_data) {
+  event_data,
+  location_data
+) {
   data <- bpt_check_data(
     location = location_data,
     event = event_data,
@@ -48,16 +49,40 @@ bpt_manipulate_data_plot <- function(
         hour = .data$start_hour,
         minute = .data$start_minute
       ),
-      groupsize = .data$fa + .data$f1 + .data$f0 + .data$fu + .data$ma +
-        .data$m3 + .data$m2 + .data$m1 + .data$m0 + .data$mu +
-        .data$ua + .data$u1 + .data$u0 + .data$uu,
+      groupsize = .data$fa +
+        .data$f1 +
+        .data$f0 +
+        .data$fu +
+        .data$ma +
+        .data$m3 +
+        .data$m2 +
+        .data$m1 +
+        .data$m0 +
+        .data$mu +
+        .data$ua +
+        .data$u1 +
+        .data$u0 +
+        .data$uu,
       year = dttr2::dtt_year(.data$datetime_start),
       study_year = dttr2::dtt_study_year(.data$datetime_start, 4L),
       month = dttr2::dtt_month(.data$datetime_start),
       dplyr::across(
         c(
-          "fa", "f1", "f0", "fu", "ma", "m3", "m2", "m1", "m0", "mu", "ua",
-          "u1", "u0", "uu", "groupsize"
+          "fa",
+          "f1",
+          "f0",
+          "fu",
+          "ma",
+          "m3",
+          "m2",
+          "m1",
+          "m0",
+          "mu",
+          "ua",
+          "u1",
+          "u0",
+          "uu",
+          "groupsize"
         ),
         \(x) base::as.integer(x)
       )
@@ -71,8 +96,24 @@ bpt_manipulate_data_plot <- function(
       date_time = "datetime_start"
     ) |>
     dplyr::select(
-      "location_id", "groupsize", "fa", "f1", "f0", "fu", "ma", "m3", "m2",
-      "m1", "m0", "mu", "ua", "u1", "u0", "uu", "study_year", "date_time",
+      "location_id",
+      "groupsize",
+      "fa",
+      "f1",
+      "f0",
+      "fu",
+      "ma",
+      "m3",
+      "m2",
+      "m1",
+      "m0",
+      "mu",
+      "ua",
+      "u1",
+      "u0",
+      "uu",
+      "study_year",
+      "date_time",
       "year"
     )
   data

--- a/R/bpt-manipulate-ratios.R
+++ b/R/bpt-manipulate-ratios.R
@@ -37,11 +37,12 @@
 #'   locations = "LOCID1"
 #' )
 bpt_manipulate_ratios <- function(
-    data,
-    numerator,
-    denominator,
-    study_years = unique(data$study_year),
-    locations = unique(data$location_id)) {
+  data,
+  numerator,
+  denominator,
+  study_years = unique(data$study_year),
+  locations = unique(data$location_id)
+) {
   chk::chk_data(data)
   chk::chk_character(numerator)
   chk::chk_character(denominator)
@@ -53,28 +54,56 @@ bpt_manipulate_ratios <- function(
   class_numerator <- all(
     numerator %in%
       c(
-        "fa", "f1", "f0", "fu", "ma", "m3", "m2", "m1", "m0", "mu", "ua",
-        "u1", "u0", "uu"
+        "fa",
+        "f1",
+        "f0",
+        "fu",
+        "ma",
+        "m3",
+        "m2",
+        "m1",
+        "m0",
+        "mu",
+        "ua",
+        "u1",
+        "u0",
+        "uu"
       )
   )
-  if (!class_numerator) stop(paste0(
-    "Numerator is not a compatible class. Ensure all elements are in: ",
-    "c('fa', 'f1', f0', 'fu', 'ma', 'm3', 'm2', 'm1', 'm0', 'mu', 'ua', 'u1', ",
-    "'u0', 'uu')."
-  ))
+  if (!class_numerator) {
+    stop(paste0(
+      "Numerator is not a compatible class. Ensure all elements are in: ",
+      "c('fa', 'f1', f0', 'fu', 'ma', 'm3', 'm2', 'm1', 'm0', 'mu', 'ua', 'u1', ",
+      "'u0', 'uu')."
+    ))
+  }
 
   class_denominator <- all(
     denominator %in%
       c(
-        "fa", "f1", "f0", "fu", "ma", "m3", "m2", "m1", "m0", "mu", "ua", "u1",
-        "u0", "uu"
+        "fa",
+        "f1",
+        "f0",
+        "fu",
+        "ma",
+        "m3",
+        "m2",
+        "m1",
+        "m0",
+        "mu",
+        "ua",
+        "u1",
+        "u0",
+        "uu"
       )
   )
-  if (!class_denominator) stop(paste0(
-    "Denominator is not a compatible class. Ensure all elements are in: ",
-    "c('fa', 'f1', f0', 'fu', 'ma', 'm3', 'm2', 'm1', 'm0', 'mu', 'ua', 'u1', ",
-    "'u0', 'uu')."
-  ))
+  if (!class_denominator) {
+    stop(paste0(
+      "Denominator is not a compatible class. Ensure all elements are in: ",
+      "c('fa', 'f1', f0', 'fu', 'ma', 'm3', 'm2', 'm1', 'm0', 'mu', 'ua', 'u1', ",
+      "'u0', 'uu')."
+    ))
+  }
 
   data$numerator <- rowSums(data[, numerator])
   data$denominator <- rowSums(data[, denominator])

--- a/R/bpt-modify-data.R
+++ b/R/bpt-modify-data.R
@@ -40,16 +40,17 @@
 #' )
 #' }
 bpt_modify_data <- function(
-    data,
-    levels_annual,
-    census,
-    census_cv,
-    census_study_year,
-    census_day_of_year,
-    proportion_calf,
-    proportion_calf_cv,
-    proportion_calf_study_year,
-    proportion_calf_day_of_year) {
+  data,
+  levels_annual,
+  census,
+  census_cv,
+  census_study_year,
+  census_day_of_year,
+  proportion_calf,
+  proportion_calf_cv,
+  proportion_calf_study_year,
+  proportion_calf_day_of_year
+) {
   chk::chk_list(data)
   df <- base::is.data.frame(data)
   if (df) {

--- a/R/bpt-plot-predictions.R
+++ b/R/bpt-plot-predictions.R
@@ -30,7 +30,8 @@
 #' bpt_plot_predictions(analysis = analysis, prediction = "ratios")
 #' }
 bpt_plot_predictions <- function(analysis, prediction = "abundance-total") {
-  preds <- base::switch(prediction,
+  preds <- base::switch(
+    prediction,
     "abundance-class" = bisonpictools::bpt_predict_abundance_class(analysis),
     "abundance-total" = bisonpictools::bpt_predict_abundance_total(analysis),
     "survival" = bisonpictools::bpt_predict_survival(analysis),
@@ -38,7 +39,8 @@ bpt_plot_predictions <- function(analysis, prediction = "abundance-total") {
     "ratios" = bisonpictools::bpt_predict_ratios(analysis)
   )
 
-  xvar <- base::switch(prediction,
+  xvar <- base::switch(
+    prediction,
     "abundance-class" = "annual",
     "abundance-total" = "annual",
     "survival" = "annual",
@@ -46,7 +48,8 @@ bpt_plot_predictions <- function(analysis, prediction = "abundance-total") {
     "ratios" = "annual"
   )
 
-  facets <- base::switch(prediction,
+  facets <- base::switch(
+    prediction,
     "abundance-class" = "class",
     "survival" = "class",
     "ratios" = "ratio",
@@ -54,13 +57,15 @@ bpt_plot_predictions <- function(analysis, prediction = "abundance-total") {
     "abundance-total" = NA_character_
   )
 
-  scales <- base::switch(prediction,
+  scales <- base::switch(
+    prediction,
     "abundance-class" = "free_y",
     "survival" = "free_y",
     "ratios" = "free_y"
   )
 
-  xlab <- base::switch(prediction,
+  xlab <- base::switch(
+    prediction,
     "abundance-class" = "Study Year",
     "abundance-total" = "Study Year",
     "survival" = "Study Year",
@@ -68,7 +73,8 @@ bpt_plot_predictions <- function(analysis, prediction = "abundance-total") {
     "ratios" = "Study Year"
   )
 
-  ylab <- base::switch(prediction,
+  ylab <- base::switch(
+    prediction,
     "abundance-class" = "Abundance",
     "abundance-total" = "Abundance",
     "survival" = "Survival Rate (%)",
@@ -76,14 +82,14 @@ bpt_plot_predictions <- function(analysis, prediction = "abundance-total") {
     "ratios" = "Ratio"
   )
 
-  expand_lims <- base::switch(prediction,
+  expand_lims <- base::switch(
+    prediction,
     "abundance-class" = c(0),
     "abundance-total" = c(0),
     "survival" = c(0, 1),
     "fecundity" = c(0, 1),
     "ratios" = c(0)
   )
-
 
   gp <- ggplot2::ggplot(preds) +
     ggplot2::geom_pointrange(

--- a/R/bpt-plot-ratios.R
+++ b/R/bpt-plot-ratios.R
@@ -15,11 +15,11 @@
 #' Plot Ratios of Wood Bison Camera Events
 #'
 #' Generates bubble plot of ratio of the sex-age classes supplied to `numerator`
-#' and `denominator`. Each point represents an event. The size of the point 
-#' represents the total group size, and the colour of the point represents the 
-#' value of the ratio. Note that a ratio value of "Inf" (infinity) indicates 
-#' that the group in a particular camera trap event has no individuals in the 
-#' denominator class. Similarly, a ratio of "0" indicates that the ratio in 
+#' and `denominator`. Each point represents an event. The size of the point
+#' represents the total group size, and the colour of the point represents the
+#' value of the ratio. Note that a ratio value of "Inf" (infinity) indicates
+#' that the group in a particular camera trap event has no individuals in the
+#' denominator class. Similarly, a ratio of "0" indicates that the ratio in
 #' a particular camera trap event has no individuals in the numerator class.
 #'
 #' @inheritParams params
@@ -47,13 +47,14 @@
 #'   locations = "LOCID1"
 #' )
 bpt_plot_ratios <- function(
-    event_data,
-    location_data,
-    numerator,
-    denominator,
-    study_years = bpt_study_years(event_data),
-    locations = unique(location_data$location_id),
-    ratio_name = "Ratio") {
+  event_data,
+  location_data,
+  numerator,
+  denominator,
+  study_years = bpt_study_years(event_data),
+  locations = unique(location_data$location_id),
+  ratio_name = "Ratio"
+) {
   data <- bpt_manipulate_data_plot(
     event_data,
     location_data
@@ -159,7 +160,10 @@ seasons_plot <- function(study_year_start) {
       )
     ) |>
     dplyr::select(
-      "season", "start_date_time", "end_date_time", "study_year"
+      "season",
+      "start_date_time",
+      "end_date_time",
+      "study_year"
     )
 }
 

--- a/R/bpt-predict-abundance-class.R
+++ b/R/bpt-predict-abundance-class.R
@@ -47,8 +47,14 @@ bpt_predict_abundance_class <- function(analysis) {
 
   abundance <-
     dplyr::bind_rows(
-      abundance_f0, abundance_f1, abundance_fa,
-      abundance_m0, abundance_m1, abundance_m2, abundance_m3, abundance_ma
+      abundance_f0,
+      abundance_f1,
+      abundance_fa,
+      abundance_m0,
+      abundance_m1,
+      abundance_m2,
+      abundance_m3,
+      abundance_ma
     ) |>
     dplyr::select("annual", "class", "estimate", "lower", "upper")
 

--- a/R/bpt-predict-fecundity.R
+++ b/R/bpt-predict-fecundity.R
@@ -44,7 +44,10 @@ bpt_predict_fecundity <- function(analysis) {
 
   rates <- dplyr::bind_rows(fecundity, prop_reproductive) |>
     dplyr::select(
-      "rate", "estimate", "lower", "upper"
+      "rate",
+      "estimate",
+      "lower",
+      "upper"
     )
 
   rates

--- a/R/bpt-predict-ratios.R
+++ b/R/bpt-predict-ratios.R
@@ -45,18 +45,34 @@ bpt_predict_ratios <- function(analysis) {
     dplyr::mutate(ratio = "MA:FA")
 
   ratios <- dplyr::bind_rows(
-    m0_f0, m1_f1, calf_fa, yearling_fa, m2_fa, m3_fa, ma_fa
+    m0_f0,
+    m1_f1,
+    calf_fa,
+    yearling_fa,
+    m2_fa,
+    m3_fa,
+    ma_fa
   ) |>
     dplyr::mutate(
       ratio = base::factor(
         .data$ratio,
         levels = c(
-          "M0:F0", "M1:F1", "Calf:FA", "Yearling:FA", "M2:FA", "M3:FA", "MA:FA"
+          "M0:F0",
+          "M1:F1",
+          "Calf:FA",
+          "Yearling:FA",
+          "M2:FA",
+          "M3:FA",
+          "MA:FA"
         )
       )
     ) |>
     dplyr::select(
-      "annual", "ratio", "estimate", "lower", "upper"
+      "annual",
+      "ratio",
+      "estimate",
+      "lower",
+      "upper"
     )
 
   ratios

--- a/R/bpt-predict-survival.R
+++ b/R/bpt-predict-survival.R
@@ -84,7 +84,11 @@ bpt_predict_survival <- function(analysis) {
       )
     ) |>
     dplyr::select(
-      "annual", "class", "estimate", "lower", "upper"
+      "annual",
+      "class",
+      "estimate",
+      "lower",
+      "upper"
     )
 
   survival

--- a/R/bpt-seasons.R
+++ b/R/bpt-seasons.R
@@ -25,10 +25,10 @@
 #' bpt_seasons()
 bpt_seasons <- function() {
   dplyr::tribble(
-    ~season, ~start_dayte, ~end_dayte,
-    "Calving", "1972-04-01 00:00:00", "1972-06-30 23:59:59",
-    "Summer/Fall", "1972-07-01 00:00:00", "1972-11-30 23:59:59",
-    "Winter", "1972-12-01 00:00:00", "1973-03-31 23:59:59"
+    ~season       , ~start_dayte          , ~end_dayte            ,
+    "Calving"     , "1972-04-01 00:00:00" , "1972-06-30 23:59:59" ,
+    "Summer/Fall" , "1972-07-01 00:00:00" , "1972-11-30 23:59:59" ,
+    "Winter"      , "1972-12-01 00:00:00" , "1973-03-31 23:59:59"
   ) |>
     dplyr::mutate(
       dplyr::across(

--- a/R/bpt-study-years.R
+++ b/R/bpt-study-years.R
@@ -29,8 +29,11 @@ bpt_study_years <- function(data) {
   census <- try(bpt_check_data(census = data), silent = TRUE)
   proportion_calf <- try(bpt_check_data(proportion_calf = data), silent = TRUE)
 
-  if (inherits(event, "try-error") && inherits(census, "try-error") &&
-    inherits(proportion_calf, "try-error")) {
+  if (
+    inherits(event, "try-error") &&
+      inherits(census, "try-error") &&
+      inherits(proportion_calf, "try-error")
+  ) {
     chk::abort_chk(
       paste0(
         "Data is not a compatible tibble. Ensure columns match the formatting ",

--- a/R/check-study-year.R
+++ b/R/check-study-year.R
@@ -30,9 +30,10 @@
 #'   proportion_calf_data
 #' )
 check_study_year <- function(
-    event_data,
-    census_data,
-    proportion_calf_data) {
+  event_data,
+  census_data,
+  proportion_calf_data
+) {
   sy_event <- bpt_study_years(event_data)
   sy_census <- bpt_study_years(census_data)
   sy_prop_calf <- bpt_study_years(proportion_calf_data)

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/inst/test-objects/save-test-analysis.R
+++ b/inst/test-objects/save-test-analysis.R
@@ -1,11 +1,11 @@
 # Copyright 2023 Province of Alberta
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -1,11 +1,11 @@
 # Copyright 2023 Province of Alberta
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/testthat/test-bpt-analyse.R
+++ b/tests/testthat/test-bpt-analyse.R
@@ -12,144 +12,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-test_that(
-  "analysis fails with negative thinning rate",
-  {
-    expect_error(
-      analysis <- bpt_analyse(
-        event_data = event_data,
-        location_data = location_data,
-        census_data = census_data,
-        proportion_calf_data = proportion_calf_data,
-        nthin = -1L,
-        analysis_mode = "quick"
-      ),
-      "`nthin` must be greater than or equal to 1."
-    )
-  }
-)
+test_that("analysis fails with negative thinning rate", {
+  expect_error(
+    analysis <- bpt_analyse(
+      event_data = event_data,
+      location_data = location_data,
+      census_data = census_data,
+      proportion_calf_data = proportion_calf_data,
+      nthin = -1L,
+      analysis_mode = "quick"
+    ),
+    "`nthin` must be greater than or equal to 1."
+  )
+})
 
-test_that(
-  "analysis fails with unrecognized analysis mode",
-  {
-    expect_error(
-      analysis <- bpt_analyse(
-        event_data = event_data,
-        location_data = location_data,
-        census_data = census_data,
-        proportion_calf_data = proportion_calf_data,
-        nthin = 1L,
-        analysis_mode = "hurry"
-      ),
-      "`analysis_mode` must match"
-    )
-  }
-)
+test_that("analysis fails with unrecognized analysis mode", {
+  expect_error(
+    analysis <- bpt_analyse(
+      event_data = event_data,
+      location_data = location_data,
+      census_data = census_data,
+      proportion_calf_data = proportion_calf_data,
+      nthin = 1L,
+      analysis_mode = "hurry"
+    ),
+    "`analysis_mode` must match"
+  )
+})
 
-test_that(
-  "analysis fails with decimal thinning rate",
-  {
-    expect_error(
-      analysis <- bpt_analyse(
-        event_data = event_data,
-        location_data = location_data,
-        census_data = census_data,
-        proportion_calf_data = proportion_calf_data,
-        nthin = 0.1,
-        analysis_mode = "quick"
-      ),
-      "`nthin` must be integer."
-    )
-  }
-)
+test_that("analysis fails with decimal thinning rate", {
+  expect_error(
+    analysis <- bpt_analyse(
+      event_data = event_data,
+      location_data = location_data,
+      census_data = census_data,
+      proportion_calf_data = proportion_calf_data,
+      nthin = 0.1,
+      analysis_mode = "quick"
+    ),
+    "`nthin` must be integer."
+  )
+})
 
-test_that(
-  "analysis fails with no inputs",
-  {
-    expect_error(
-      analysis <- bpt_analyse(),
-      "argument \"event_data\" is missing, with no default"
-    )
-  }
-)
+test_that("analysis fails with no inputs", {
+  expect_error(
+    analysis <- bpt_analyse(),
+    "argument \"event_data\" is missing, with no default"
+  )
+})
 
-test_that(
-  "analysis fails missing event_data input",
-  {
-    expect_error(
-      analysis <- bpt_analyse(
-        location_data = location_data,
-        proportion_calf_data = proportion_calf_data,
-        census_data = census_data,
-        nthin = 1L,
-        analysis_mode = "quick"
-      ),
-      "argument \"event_data\" is missing, with no default"
-    )
-  }
-)
+test_that("analysis fails missing event_data input", {
+  expect_error(
+    analysis <- bpt_analyse(
+      location_data = location_data,
+      proportion_calf_data = proportion_calf_data,
+      census_data = census_data,
+      nthin = 1L,
+      analysis_mode = "quick"
+    ),
+    "argument \"event_data\" is missing, with no default"
+  )
+})
 
-test_that(
-  "analysis fails missing location_data input",
-  {
-    expect_error(
-      analysis <- bpt_analyse(
-        event_data = event_data,
-        proportion_calf_data = proportion_calf_data,
-        census_data = census_data,
-        nthin = 1L,
-        analysis_mode = "quick"
-      ),
-      "argument \"location_data\" is missing, with no default"
-    )
-  }
-)
+test_that("analysis fails missing location_data input", {
+  expect_error(
+    analysis <- bpt_analyse(
+      event_data = event_data,
+      proportion_calf_data = proportion_calf_data,
+      census_data = census_data,
+      nthin = 1L,
+      analysis_mode = "quick"
+    ),
+    "argument \"location_data\" is missing, with no default"
+  )
+})
 
-test_that(
-  "analysis fails missing census_data input",
-  {
-    expect_error(
-      analysis <- bpt_analyse(
-        event_data = event_data,
-        location_data = location_data,
-        proportion_calf_data = proportion_calf_data,
-        nthin = 1L,
-        analysis_mode = "quick"
-      ),
-      "argument \"census_data\" is missing, with no default"
-    )
-  }
-)
+test_that("analysis fails missing census_data input", {
+  expect_error(
+    analysis <- bpt_analyse(
+      event_data = event_data,
+      location_data = location_data,
+      proportion_calf_data = proportion_calf_data,
+      nthin = 1L,
+      analysis_mode = "quick"
+    ),
+    "argument \"census_data\" is missing, with no default"
+  )
+})
 
-test_that(
-  "analysis fails missing proportion_calf_data input",
-  {
-    expect_error(
-      analysis <- bpt_analyse(
-        event_data = event_data,
-        location_data = location_data,
-        census_data = census_data,
-        nthin = 1L,
-        analysis_mode = "quick"
-      ),
-      "argument \"proportion_calf_data\" is missing, with no default"
-    )
-  }
-)
+test_that("analysis fails missing proportion_calf_data input", {
+  expect_error(
+    analysis <- bpt_analyse(
+      event_data = event_data,
+      location_data = location_data,
+      census_data = census_data,
+      nthin = 1L,
+      analysis_mode = "quick"
+    ),
+    "argument \"proportion_calf_data\" is missing, with no default"
+  )
+})
 
-test_that(
-  "analysis fails providing wrong data",
-  {
-    expect_error(
-      analysis <- bpt_analyse(
-        event_data = event_data,
-        location_data = location_data,
-        census_data = census_data,
-        proportion_calf_data = census_data,
-        nthin = 1L,
-        analysis_mode = "quick"
-      ),
-      "Column names in data must include 'proportion_calf', 'proportion_calf_cv', 'proportion_calf_day', 'proportion_calf_month' and 'proportion_calf_year'."
-    )
-  }
-)
+test_that("analysis fails providing wrong data", {
+  expect_error(
+    analysis <- bpt_analyse(
+      event_data = event_data,
+      location_data = location_data,
+      census_data = census_data,
+      proportion_calf_data = census_data,
+      nthin = 1L,
+      analysis_mode = "quick"
+    ),
+    "Column names in data must include 'proportion_calf', 'proportion_calf_cv', 'proportion_calf_day', 'proportion_calf_month' and 'proportion_calf_year'."
+  )
+})

--- a/tests/testthat/test-bpt-check-data.R
+++ b/tests/testthat/test-bpt-check-data.R
@@ -116,8 +116,7 @@ test_that("event table only errors as complete set to TRUE", {
 
   expect_error(
     bpt_check_data(event = event_data, complete = TRUE),
-    regexp =
-      "The `complete = TRUE` argument was provided but not all data sets were
+    regexp = "The `complete = TRUE` argument was provided but not all data sets were
         supplied. Either change `complete = FALSE` or supply all the data in the
         `...` argument."
   )
@@ -132,8 +131,7 @@ test_that("location table only errors as complete set to TRUE", {
 
   expect_error(
     bpt_check_data(location = location_data, complete = TRUE),
-    regexp =
-      "The `complete = TRUE` argument was provided but not all data sets were
+    regexp = "The `complete = TRUE` argument was provided but not all data sets were
         supplied. Either change `complete = FALSE` or supply all the data in the
         `...` argument."
   )
@@ -150,8 +148,7 @@ test_that("census table only errors as complete set to TRUE", {
 
   expect_error(
     bpt_check_data(census = census_data, complete = TRUE),
-    regexp =
-      "The `complete = TRUE` argument was provided but not all data sets were
+    regexp = "The `complete = TRUE` argument was provided but not all data sets were
         supplied. Either change `complete = FALSE` or supply all the data in the
         `...` argument."
   )
@@ -168,8 +165,7 @@ test_that("calf proportion table only errors as complete set to TRUE", {
 
   expect_error(
     bpt_check_data(proportion_calf = proportion_calf_data, complete = TRUE),
-    regexp =
-      "The `complete = TRUE` argument was provided but not all data sets were
+    regexp = "The `complete = TRUE` argument was provided but not all data sets were
         supplied. Either change `complete = FALSE` or supply all the data in the
         `...` argument."
   )

--- a/tests/testthat/test-bpt-manipulate-data-analysis.R
+++ b/tests/testthat/test-bpt-manipulate-data-analysis.R
@@ -68,24 +68,21 @@ test_that("non-coercable characters in 'f0' column produces error", {
   )
 })
 
-test_that(
-  "errors if census date is outside of range of study years in event_data",
-  {
-    expect_chk_error(
-      bpt_manipulate_data_analysis(
-        event_data,
-        location_data,
-        census_data |>
-          dplyr::mutate(census_year = c(2030, 2031)),
-        proportion_calf_data
-      ),
-      regexp = paste0(
-        "Census data must include only dates that are within the study years ",
-        "of the event data."
-      )
+test_that("errors if census date is outside of range of study years in event_data", {
+  expect_chk_error(
+    bpt_manipulate_data_analysis(
+      event_data,
+      location_data,
+      census_data |>
+        dplyr::mutate(census_year = c(2030, 2031)),
+      proportion_calf_data
+    ),
+    regexp = paste0(
+      "Census data must include only dates that are within the study years ",
+      "of the event data."
     )
-  }
-)
+  )
+})
 
 # Expected outputs
 test_that("returns list", {
@@ -190,7 +187,17 @@ test_that("week_fac column has correct levels", {
     all(
       levels(x$data$weekfac) ==
         c(
-          "1", "22", "35", "42", "49", "51", "79", "92", "100", "111", "130",
+          "1",
+          "22",
+          "35",
+          "42",
+          "49",
+          "51",
+          "79",
+          "92",
+          "100",
+          "111",
+          "130",
           "148"
         )
     )
@@ -216,8 +223,7 @@ test_that("season column has correct levels", {
   )
   expect_true(
     all(
-      levels(x$data$season) ==
-        c("Summer/Fall", "Winter")
+      levels(x$data$season) == c("Summer/Fall", "Winter")
     )
   )
 })
@@ -243,8 +249,12 @@ test_that("season_annual column has correct levels", {
     all(
       levels(x$data$season_annual) ==
         c(
-          "Winter 2018-2019", "Summer/Fall 2019-2020", "Winter 2019-2020",
-          "Summer/Fall 2020-2021", "Winter 2020-2021", "Summer/Fall 2021-2022",
+          "Winter 2018-2019",
+          "Summer/Fall 2019-2020",
+          "Winter 2019-2020",
+          "Summer/Fall 2020-2021",
+          "Winter 2020-2021",
+          "Summer/Fall 2021-2022",
           "Winter 2021-2022"
         )
     )
@@ -286,8 +296,18 @@ test_that("doy_fac column has correct levels", {
     all(
       levels(x$data$doy_fac) ==
         c(
-          "12", "122", "146", "158", "212", "246", "261", "269", "302",
-          "313", "327", "336"
+          "12",
+          "122",
+          "146",
+          "158",
+          "212",
+          "246",
+          "261",
+          "269",
+          "302",
+          "313",
+          "327",
+          "336"
         )
     )
   )
@@ -312,8 +332,7 @@ test_that("location column has correct levels", {
   )
   expect_true(
     all(
-      levels(x$data$location) ==
-        c("LOCID1", "LOCID2", "LOCID3", "LOCID4")
+      levels(x$data$location) == c("LOCID1", "LOCID2", "LOCID3", "LOCID4")
     )
   )
 })
@@ -339,8 +358,16 @@ test_that("location_weekfac column has correct levels", {
     all(
       levels(x$data$location_weekfac) ==
         c(
-          "LOCID1 130", "LOCID1 22", "LOCID1 79", "LOCID2 35", "LOCID2 92",
-          "LOCID3 100", "LOCID3 42", "LOCID3 51", "LOCID4 1", "LOCID4 148",
+          "LOCID1 130",
+          "LOCID1 22",
+          "LOCID1 79",
+          "LOCID2 35",
+          "LOCID2 92",
+          "LOCID3 100",
+          "LOCID3 42",
+          "LOCID3 51",
+          "LOCID4 1",
+          "LOCID4 148",
           "LOCID4 49"
         )
     )
@@ -520,8 +547,10 @@ test_that("prop_calf_doy column is an integer between 1 and 366", {
     proportion_calf_data = proportion_calf_data
   )
   expect_true(
-    all(x$prop_calf_data$prop_calf_doy >= 1 &
-      x$prop_calf_data$prop_calf_doy <= 366)
+    all(
+      x$prop_calf_data$prop_calf_doy >= 1 &
+        x$prop_calf_data$prop_calf_doy <= 366
+    )
   )
   expect_true(all(is.integer(x$prop_calf_data$prop_calf_doy)))
 })

--- a/tests/testthat/test-bpt-manipulate-location-matrix.R
+++ b/tests/testthat/test-bpt-manipulate-location-matrix.R
@@ -16,8 +16,7 @@
 test_that("errors with null input", {
   expect_chk_error(
     bpt_location_matrix(NULL),
-    regexp =
-      "The names of the data supplied in the `...` argument do not match the
+    regexp = "The names of the data supplied in the `...` argument do not match the
       template names."
   )
 })

--- a/tests/testthat/test-bpt-manipulate-ratios.R
+++ b/tests/testthat/test-bpt-manipulate-ratios.R
@@ -58,7 +58,8 @@ test_that("same number of rows as event_data without filtering", {
     denominator = "f1"
   )
   expect_equal(
-    nrow(x), nrow(event_data |> dplyr::filter(f0 > 0 | f1 > 0))
+    nrow(x),
+    nrow(event_data |> dplyr::filter(f0 > 0 | f1 > 0))
   )
 })
 

--- a/tests/testthat/test-bpt-modify-data.R
+++ b/tests/testthat/test-bpt-modify-data.R
@@ -513,33 +513,30 @@ test_that("errors if census_study_year is not a subset of levels_annual", {
   )
 })
 
-test_that(
-  "errors if proportion_calf_study_year is not a subset of levels_annual",
-  {
-    expect_chk_error(
-      bpt_modify_data(
-        data = list(
-          annual = as.factor(c("2021-2022", "2022-2023")),
-          x = 1:2,
-          y = 10:11
-        ),
-        levels_annual = levels(as.factor(c("2021-2022", "2022-2023"))),
-        census = 200L,
-        census_cv = 0.2,
-        census_study_year = c("2021-2022"),
-        census_day_of_year = 365L,
-        proportion_calf = c(0.2, 0.3),
-        proportion_calf_cv = c(0.5, 0.5),
-        proportion_calf_study_year = c("2021-2022", "2026-2027"),
-        proportion_calf_day_of_year = c(365L, 365L)
+test_that("errors if proportion_calf_study_year is not a subset of levels_annual", {
+  expect_chk_error(
+    bpt_modify_data(
+      data = list(
+        annual = as.factor(c("2021-2022", "2022-2023")),
+        x = 1:2,
+        y = 10:11
       ),
-      regexp = paste0(
-        "`proportion_calf_study_year` must have values matching '2021-2022' ",
-        "or '2022-2023'."
-      )
+      levels_annual = levels(as.factor(c("2021-2022", "2022-2023"))),
+      census = 200L,
+      census_cv = 0.2,
+      census_study_year = c("2021-2022"),
+      census_day_of_year = 365L,
+      proportion_calf = c(0.2, 0.3),
+      proportion_calf_cv = c(0.5, 0.5),
+      proportion_calf_study_year = c("2021-2022", "2026-2027"),
+      proportion_calf_day_of_year = c(365L, 365L)
+    ),
+    regexp = paste0(
+      "`proportion_calf_study_year` must have values matching '2021-2022' ",
+      "or '2022-2023'."
     )
-  }
-)
+  )
+})
 
 
 test_that("errors if census_day_of_year is not an integer", {

--- a/tests/testthat/test-bpt-plot-predictions.R
+++ b/tests/testthat/test-bpt-plot-predictions.R
@@ -69,16 +69,13 @@ test_that("plot is ggplot if we turn off snapshots", {
   expect_s3_class(plot, "ggplot")
 })
 
-test_that(
-  "default prediction type gives same type as the abundance-total specifies",
-  {
-    plot1 <- bpt_plot_predictions(
-      analysis = analysis
-    )
-    plot2 <- bpt_plot_predictions(
-      analysis = analysis,
-      prediction = "abundance-total"
-    )
-    expect_equal(plot1, plot2)
-  }
-)
+test_that("default prediction type gives same type as the abundance-total specifies", {
+  plot1 <- bpt_plot_predictions(
+    analysis = analysis
+  )
+  plot2 <- bpt_plot_predictions(
+    analysis = analysis,
+    prediction = "abundance-total"
+  )
+  expect_equal(plot1, plot2)
+})

--- a/tests/testthat/test-bpt-seasons.R
+++ b/tests/testthat/test-bpt-seasons.R
@@ -13,18 +13,21 @@
 # limitations under the License.
 
 test_that("seasons returns tibble with expected start and end daytes", {
-  expect_equal(bpt_seasons(), dplyr::tribble(
-    ~season, ~start_dayte, ~end_dayte,
-    "Calving", "1972-04-01 00:00:00", "1972-06-30 23:59:59",
-    "Summer/Fall", "1972-07-01 00:00:00", "1972-11-30 23:59:59",
-    "Winter", "1972-12-01 00:00:00", "1973-03-31 23:59:59"
-  ) |>
-    dplyr::mutate(
-      dplyr::across(
-        c("start_dayte", "end_dayte"),
-        \(x) dttr2::dtt_date_time(x)
+  expect_equal(
+    bpt_seasons(),
+    dplyr::tribble(
+      ~season       , ~start_dayte          , ~end_dayte            ,
+      "Calving"     , "1972-04-01 00:00:00" , "1972-06-30 23:59:59" ,
+      "Summer/Fall" , "1972-07-01 00:00:00" , "1972-11-30 23:59:59" ,
+      "Winter"      , "1972-12-01 00:00:00" , "1973-03-31 23:59:59"
+    ) |>
+      dplyr::mutate(
+        dplyr::across(
+          c("start_dayte", "end_dayte"),
+          \(x) dttr2::dtt_date_time(x)
+        )
       )
-    ))
+  )
 })
 
 test_that("seasons errors with arguments", {

--- a/tests/testthat/test-check-study-year.R
+++ b/tests/testthat/test-check-study-year.R
@@ -40,35 +40,29 @@ test_that("NULL inputs throw error", {
 })
 
 
-test_that(
-  "errors if study years of census data don't match those of event data",
-  {
-    census_data <- census_data |>
-      dplyr::mutate(census_year = c(2030, 2031))
-    expect_chk_error(
-      check_study_year(event_data, census_data, proportion_calf_data),
-      regexp = paste0(
-        "Census data must include only dates that are within the study years ",
-        "of the event data."
-      )
+test_that("errors if study years of census data don't match those of event data", {
+  census_data <- census_data |>
+    dplyr::mutate(census_year = c(2030, 2031))
+  expect_chk_error(
+    check_study_year(event_data, census_data, proportion_calf_data),
+    regexp = paste0(
+      "Census data must include only dates that are within the study years ",
+      "of the event data."
     )
-  }
-)
+  )
+})
 
-test_that(
-  "errors if study years of census data don't match those of event data",
-  {
-    prop_calf_data <- proportion_calf_data |>
-      dplyr::mutate(proportion_calf_year = c(2030, 2031))
-    expect_chk_error(
-      check_study_year(event_data, census_data, prop_calf_data),
-      regexp = paste0(
-        "Calf proportion data must include only dates that are within the ",
-        "study years of the event data."
-      )
+test_that("errors if study years of census data don't match those of event data", {
+  prop_calf_data <- proportion_calf_data |>
+    dplyr::mutate(proportion_calf_year = c(2030, 2031))
+  expect_chk_error(
+    check_study_year(event_data, census_data, prop_calf_data),
+    regexp = paste0(
+      "Calf proportion data must include only dates that are within the ",
+      "study years of the event data."
     )
-  }
-)
+  )
+})
 
 test_that(
   paste0(


### PR DESCRIPTION
Closes #60

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)